### PR TITLE
Legend adjustments

### DIFF
--- a/Part2/Part2_Frontend/src/lib/Chart.svelte
+++ b/Part2/Part2_Frontend/src/lib/Chart.svelte
@@ -44,6 +44,7 @@
   let nodeColorMap = new Map<string, string>();
 
   let showLegend = false;
+  let legendPinned = false;
   let panelX = 20;
   let panelY = 20;
 
@@ -148,7 +149,7 @@
         // Check if the source/target is already a duplicate
         const sourceNode = nodes.find(n => n.id === l.source);
         const targetNode = nodes.find(n => n.id === l.target);
-        
+
         if (gSrc === firstGenome && !sourceNode?._dup) {
           const newLink = { ...l, source: dupMap.get(l.source)! };
           console.log('Link transformed for duplication (source):', {
@@ -1045,12 +1046,25 @@
     <button
       type="button"
       class="absolute top-2 right-2 w-7 h-7 bg-white border border-slate-200 rounded-lg shadow-sm hover:bg-slate-50 transition-colors cursor-pointer flex items-center justify-center text-slate-600 hover:text-slate-800"
-      on:click={() => showLegend = !showLegend}
-      on:mouseenter={() => showLegend = true}
-      on:mouseleave={() => showLegend = false}
-      on:keydown={(e) => e.key === 'Enter' && (showLegend = !showLegend)}
+      on:click={() => {
+        legendPinned = !legendPinned;
+        showLegend = legendPinned;
+      }}
+      on:mouseenter={() => {
+        if (!legendPinned) showLegend = true;
+      }}
+      on:mouseleave={() => {
+        if (!legendPinned) showLegend = false;
+      }}
+      on:keydown={(e) => {
+        if (e.key === 'Enter') {
+          legendPinned = !legendPinned;
+          showLegend = legendPinned;
+        }
+      }}
       aria-expanded={showLegend}
       aria-label="Toggle legend"
+      class:pinned={legendPinned}
     >
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="10"/>
@@ -1452,5 +1466,11 @@
   }
   .svg-text p {
     margin: 4px 0;
+  }
+
+  /* Add styling for pinned legend button */
+  .pinned {
+    background-color: #e2e8f0 !important;
+    border-color: #64748b !important;
   }
 </style>

--- a/Part2/Part2_Frontend/src/lib/Chart.svelte
+++ b/Part2/Part2_Frontend/src/lib/Chart.svelte
@@ -1166,7 +1166,7 @@
                     <svg width="48" height="16" viewBox="0 0 60 20">
                       <line x1="5" y1="10" x2="45" y2="10" stroke="#bbb" stroke-width="2" stroke-dasharray="4,4" />
                     </svg>
-                    <span class="text-xs text-slate-600">Gray dotted: Non-reciprocal</span>
+                    <span class="text-xs text-slate-600">Grey dotted: Non-reciprocal</span>
                   </div>
                 {/if}
               </div>

--- a/Part2/Part2_Frontend/src/lib/Chart.svelte
+++ b/Part2/Part2_Frontend/src/lib/Chart.svelte
@@ -1079,7 +1079,17 @@
               <div class="space-y-1.5">
                 <div class="flex items-center gap-2">
                   <svg width="32" height="16" viewBox="-25 -15 50 30">
-                    <path d="M -25,-15 L 10,-15 L 25,0 L 10,15 L -25,15 Z" fill="#1f77b4" />
+                    <defs>
+                      <linearGradient id="rainbow-node" x1="0%" y1="0%" x2="100%" y2="0%">
+                        <stop offset="0%" style="stop-color:#ff8800"/>
+                        <stop offset="20%" style="stop-color:#ffff00"/>
+                        <stop offset="40%" style="stop-color:#00ff00"/>
+                        <stop offset="60%" style="stop-color:#0088ff"/>
+                        <stop offset="80%" style="stop-color:#4400ff"/>
+                        <stop offset="100%" style="stop-color:#8800ff"/>
+                      </linearGradient>
+                    </defs>
+                    <path d="M -25,-15 L 10,-15 L 25,0 L 10,15 L -25,15 Z" fill="url(#rainbow-node)" />
                   </svg>
                   <span class="text-xs text-slate-600">Colored: Strongly related nodes</span>
                 </div>
@@ -1106,9 +1116,17 @@
                 {#if graph.domain_name === "ALL"}
                   <div class="flex items-center gap-2">
                     <svg width="48" height="16" viewBox="0 0 60 20">
-                      <line x1="5" y1="10" x2="45" y2="10" stroke="#1f77b4" stroke-width="2" />
+                      <!-- Multiple colored segments for rainbow effect, same total length as others -->
+                      <line x1="5" y1="10" x2="13" y2="10" stroke="#ff8800" stroke-width="2" />
+                      <line x1="13" y1="10" x2="21" y2="10" stroke="#ffdd00" stroke-width="2" />
+                      <line x1="21" y1="10" x2="29" y2="10" stroke="#88ff00" stroke-width="2" />
+                      <line x1="29" y1="10" x2="37" y2="10" stroke="#00ccff" stroke-width="2" />
+                      <line x1="37" y1="10" x2="45" y2="10" stroke="#8866ff" stroke-width="2" />
                     </svg>
-                    <span class="text-xs text-slate-600">Solid: Consistent across domains</span>
+                    <div class="text-xs text-slate-600">
+                      <div>Colored solid: Consistently</div>
+                      <div>reciprocal* across domains</div>
+                    </div>
                   </div>
                   <div class="flex items-center gap-2">
                     <svg width="48" height="16" viewBox="0 0 60 20">
@@ -1118,9 +1136,13 @@
                   </div>
                   <div class="flex items-center gap-2">
                     <svg width="48" height="16" viewBox="0 0 60 20">
-                      <line x1="5" y1="10" x2="45" y2="10" stroke="#1f77b4" stroke-width="2" stroke-dasharray="4,4" />
+                      <line x1="5" y1="10" x2="13" y2="10" stroke="#ff8800" stroke-width="2" stroke-dasharray="4,4" />
+                      <line x1="13" y1="10" x2="21" y2="10" stroke="#ffdd00" stroke-width="2" stroke-dasharray="4,4" />
+                      <line x1="21" y1="10" x2="29" y2="10" stroke="#88ff00" stroke-width="2" stroke-dasharray="4,4" />
+                      <line x1="29" y1="10" x2="37" y2="10" stroke="#00ccff" stroke-width="2" stroke-dasharray="4,4" />
+                      <line x1="37" y1="10" x2="45" y2="10" stroke="#8866ff" stroke-width="2" stroke-dasharray="4,4" />
                     </svg>
-                    <span class="text-xs text-slate-600">Dotted: Partially consistent</span>
+                    <span class="text-xs text-slate-600">Colored dotted: Partially consistent</span>
                   </div>
                   <div class="flex items-center gap-2">
                     <svg width="48" height="16" viewBox="0 0 60 20">
@@ -1131,17 +1153,31 @@
                 {:else}
                   <div class="flex items-center gap-2">
                     <svg width="48" height="16" viewBox="0 0 60 20">
-                      <line x1="5" y1="10" x2="45" y2="10" stroke="#1f77b4" stroke-width="2" />
+                      <!-- Multiple colored segments for rainbow effect, same total length as others -->
+                      <line x1="5" y1="10" x2="13" y2="10" stroke="#ff8800" stroke-width="2" />
+                      <line x1="13" y1="10" x2="21" y2="10" stroke="#ffdd00" stroke-width="2" />
+                      <line x1="21" y1="10" x2="29" y2="10" stroke="#88ff00" stroke-width="2" />
+                      <line x1="29" y1="10" x2="37" y2="10" stroke="#00ccff" stroke-width="2" />
+                      <line x1="37" y1="10" x2="45" y2="10" stroke="#8866ff" stroke-width="2" />
                     </svg>
-                    <span class="text-xs text-slate-600">Solid: Reciprocal connection</span>
+                    <span class="text-xs text-slate-600">Colored solid: Reciprocal* connection</span>
                   </div>
                   <div class="flex items-center gap-2">
                     <svg width="48" height="16" viewBox="0 0 60 20">
                       <line x1="5" y1="10" x2="45" y2="10" stroke="#bbb" stroke-width="2" stroke-dasharray="4,4" />
                     </svg>
-                    <span class="text-xs text-slate-600">Dotted: Non-reciprocal</span>
+                    <span class="text-xs text-slate-600">Gray dotted: Non-reciprocal</span>
                   </div>
                 {/if}
+              </div>
+            </div>
+
+            <div class="space-y-1">
+              <div class="text-xs text-slate-500 border-t border-slate-100 pt-2">
+                <p><strong>*Reciprocal:</strong> Both proteins are each other's best match</p>
+                <p class="mt-1 text-slate-400">
+                  <a href="/help" class="hover:text-slate-600 underline">See help page for detailed explanations</a>
+                </p>
               </div>
             </div>
           </div>

--- a/Part2/Part2_Frontend/src/lib/Chart.svelte
+++ b/Part2/Part2_Frontend/src/lib/Chart.svelte
@@ -250,7 +250,7 @@
     ];
     const colorScale = d3.scaleOrdinal(customColors).domain(colorRoots);
     // const colorScale = d3.scaleOrdinal([...d3.schemeSet3]).domain(colorRoots);
-    // Gray-out CCs not associated with colorRoots
+    // Grey-out CCs not associated with colorRoots
     const nodeColor = new Map(
       nodes.map((n) => {
         if (n.is_present === false) return [n.id, '#e6e6e6']
@@ -1097,14 +1097,14 @@
                   <svg width="32" height="16" viewBox="-25 -15 50 30">
                     <path d="M -25,-15 L 10,-15 L 25,0 L 10,15 L -25,15 Z" fill="#7f7f7f" />
                   </svg>
-                  <span class="text-xs text-slate-600">Gray: Unrelated nodes</span>
+                  <span class="text-xs text-slate-600">Grey: Unrelated nodes</span>
                 </div>
                 {#if graph.domain_name === "ALL"}
                   <div class="flex items-center gap-2">
                     <svg width="32" height="16" viewBox="-25 -15 50 30">
                       <path d="M -25,-15 L 10,-15 L 25,0 L 10,15 L -25,15 Z" fill="#e6e6e6" />
                     </svg>
-                    <span class="text-xs text-slate-600">Light gray: Missing in domain</span>
+                    <span class="text-xs text-slate-600">Light grey: Missing in domain</span>
                   </div>
                 {/if}
               </div>
@@ -1148,7 +1148,7 @@
                     <svg width="48" height="16" viewBox="0 0 60 20">
                       <line x1="5" y1="10" x2="45" y2="10" stroke="#bbb" stroke-width="2" stroke-dasharray="4,4" />
                     </svg>
-                    <span class="text-xs text-slate-600">Gray dotted: Non-reciprocal</span>
+                    <span class="text-xs text-slate-600">Grey dotted: Non-reciprocal</span>
                   </div>
                 {:else}
                   <div class="flex items-center gap-2">


### PR DESCRIPTION
Modified legend according to user testing and our discussions. It uses rainbow colors instead of blue, and the text is more descriptive (including a link to the help page for more info). It is also toggleable, so the user can click on it to keep it open.

General case:
![image](https://github.com/user-attachments/assets/b539b11b-6630-4edf-b0d0-3bcb98c52b98)

Domain case:
![image](https://github.com/user-attachments/assets/29040460-16b0-4772-9645-8b9836380fb1)
