### PR TITLE
Dashboard tweaks + renaming "groups" to "projects"

### DIFF
--- a/Part2/Part2_Backend/server.py
+++ b/Part2/Part2_Backend/server.py
@@ -86,7 +86,7 @@ def get_group_graph():
         # Fetch group information
         group = session.query(Group).filter_by(id=group_id).first()
         if not group:
-            return jsonify({"error": "Group not found"}), 404
+            return jsonify({"error": "Project not found"}), 404
 
         # Fetch associated files
         files = session.query(File).filter_by(group_id=group_id).all()
@@ -117,7 +117,7 @@ def get_group_graph():
                 graph_s3_key = file.s3_key
 
         if not (matrix_files and coordinate_file and graph_s3_key):
-            return jsonify({"error": "Matrix/coordinate/graph file not found for this group"}), 400
+            return jsonify({"error": "Matrix/coordinate/graph file not found for this project"}), 400
 
         graph_str = s3_client.get_object(
             Bucket=os.getenv('S3_BUCKET_NAME'), Key=graph_s3_key)["Body"].read().decode()
@@ -272,11 +272,11 @@ def save_files():
             group.description = description
             session.commit()
 
-            return jsonify({"message": "Group updated successfully", "group_id": group_id}), 200
+            return jsonify({"message": "Project updated successfully", "group_id": group_id}), 200
 
         # Handle new group creation
         if not coordinate_file or not matrix_files:
-            return jsonify({"error": "Coordinate file and at least one matrix file are required for new groups"}), 400
+            return jsonify({"error": "Coordinate file and at least one matrix file are required for new projects"}), 400
 
         new_group = Group(
             user_id=user.id,
@@ -311,7 +311,7 @@ def save_files():
 
         session.commit()
 
-        return jsonify({"message": "Files and group saved successfully", "group_id": group_id}), 200
+        return jsonify({"message": "Files and project saved successfully", "group_id": group_id}), 200
 
     except Exception as e:
         session.rollback()
@@ -364,7 +364,7 @@ def get_user_file_groups():
 
     except Exception as e:
         session.rollback()
-        return jsonify({"error": f"Failed to retrieve file groups: {str(e)}"}), 500
+        return jsonify({"error": f"Failed to retrieve projects: {str(e)}"}), 500
 
     finally:
         session.close()
@@ -457,7 +457,7 @@ def delete_group():
         # Find group and verify ownership
         group = session.query(Group).filter_by(id=group_id, user_id=user.id).first()
         if not group:
-            return jsonify({"error": "Group not found or unauthorized"}), 404
+            return jsonify({"error": "Project not found"}), 404
 
         # Get all files associated with the group
         files = session.query(File).filter_by(group_id=group_id).all()
@@ -481,11 +481,11 @@ def delete_group():
         session.delete(group)
         session.commit()
 
-        return jsonify({"message": "Group and associated files deleted successfully"}), 200
+        return jsonify({"message": "Project and associated files deleted successfully"}), 200
 
     except Exception as e:
         session.rollback()
-        return jsonify({"error": f"Failed to delete group: {str(e)}"}), 500
+        return jsonify({"error": f"Failed to delete project: {str(e)}"}), 500
 
     finally:
         session.close()

--- a/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
+++ b/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
@@ -168,9 +168,20 @@
 
 {#if isAuthenticated}
 <div class="w-[95%] max-w-[1600px] mx-auto py-8">
-	<div class="mb-8">
-		<h1 class="text-3xl font-bold text-slate-800 mb-2">Your Uploads</h1>
-		<p class="text-slate-600">Manage and analyze your protein sequence comparisons</p>
+	<div class="mb-8 flex items-start justify-between">
+		<div>
+			<h1 class="text-3xl font-bold text-slate-800 mb-2">Your Uploads</h1>
+			<p class="text-slate-600">Manage and analyze your protein sequence comparisons</p>
+		</div>
+		<a
+			href="/diagram"
+			class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition-colors duration-200 cursor-pointer"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
+				<path d="M12 5v14M5 12h14"/>
+			</svg>
+			Create New Diagram
+		</a>
 	</div>
 
 	<div class="flex flex-col md:flex-row gap-4 mb-6">
@@ -237,30 +248,32 @@
 	{#if filteredFileGroups.length > 0}
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 			{#each filteredFileGroups as group}
-				<div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4 hover:shadow-md transition-shadow">
-					<div class="flex items-start justify-between mb-2">
-						<div class="flex items-center">
-							<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-400 mr-2">
-								<circle cx="6" cy="8" r="2"/>
-								<circle cx="18" cy="8" r="2"/>
-								<circle cx="6" cy="16" r="2"/>
-								<circle cx="18" cy="16" r="2"/>
-								<line x1="6" y1="8" x2="18" y2="8"/>
-								<line x1="6" y1="16" x2="18" y2="16"/>
-								<line x1="6" y1="8" x2="18" y2="16"/>
-							</svg>
-							<h3 class="font-medium text-slate-800">{group.title}</h3>
+				<div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4 hover:shadow-md transition-shadow flex flex-col h-full">
+					<div class="flex-1">
+						<div class="flex items-start justify-between mb-2">
+							<div class="flex items-center">
+								<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-400 mr-2">
+									<circle cx="6" cy="8" r="2"/>
+									<circle cx="18" cy="8" r="2"/>
+									<circle cx="6" cy="16" r="2"/>
+									<circle cx="18" cy="16" r="2"/>
+									<line x1="6" y1="8" x2="18" y2="8"/>
+									<line x1="6" y1="16" x2="18" y2="16"/>
+									<line x1="6" y1="8" x2="18" y2="16"/>
+								</svg>
+								<h3 class="font-medium text-slate-800">{group.title}</h3>
+							</div>
 						</div>
-					</div>
-					<div class="mb-3">
-						<p class="text-sm text-slate-600 line-clamp-2">{group.description}</p>
-					</div>
-					<div class="space-y-2 text-sm text-slate-600">
-						<p>Genomes: {group.genomes.join(', ')}</p>
-						<p>Num Genes: {group.num_genes}</p>
-						<p>Num Domains: {group.num_domains}</p>
-						<p>Created: {new Date(group.created_at).toLocaleString()}</p>
-						<p>Last Updated: {new Date(group.last_updated_at).toLocaleString()}</p>
+						<div class="mb-3">
+							<p class="text-sm text-slate-600 line-clamp-2">{group.description}</p>
+						</div>
+						<div class="space-y-2 text-sm text-slate-600">
+							<p>Genomes: {group.genomes.join(', ')}</p>
+							<p>Num Genes: {group.num_genes}</p>
+							<p>Num Domains: {group.num_domains}</p>
+							<p>Created: {new Date(group.created_at).toLocaleString()}</p>
+							<p>Last Updated: {new Date(group.last_updated_at).toLocaleString()}</p>
+						</div>
 					</div>
 					<div class="mt-4 flex items-center justify-between">
 						<span class={`text-xs px-2 py-1 rounded-full ${group.is_domain_specific ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700'}`}>

--- a/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
+++ b/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
@@ -185,8 +185,8 @@
 	</div>
 
 	<div class="flex flex-col md:flex-row gap-4 mb-6">
-		<div class="md:w-1/3">
-			<div class="relative">
+		<div class="md:w-1/3 flex items-end">
+			<div class="relative w-full">
 				<input
 					type="text"
 					bind:value={searchQuery}
@@ -212,7 +212,9 @@
 		</div>
 		<div class="flex gap-4 md:ml-auto">
 			<div class="w-48">
+				<label for="sort-select" class="block text-xs font-medium text-slate-700 mb-1">Sort by:</label>
 				<select
+					id="sort-select"
 					bind:value={sortBy}
 					class="w-full px-4 py-2 bg-white border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
 				>
@@ -222,7 +224,9 @@
 				</select>
 			</div>
 			<div class="w-48">
+				<label for="filter-select" class="block text-xs font-medium text-slate-700 mb-1">Filter by:</label>
 				<select
+					id="filter-select"
 					bind:value={filterBy}
 					class="w-full px-4 py-2 bg-white border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
 				>
@@ -233,6 +237,23 @@
 			</div>
 		</div>
 	</div>
+
+	{#if !loading && filteredFileGroups.length >= 0}
+		<div class="mb-4">
+			<p class="text-sm text-slate-600">
+				Showing {filteredFileGroups.length} of {userFileGroups.length} group{userFileGroups.length !== 1 ? 's' : ''}
+				{#if searchQuery || filterBy !== 'all'}
+					{#if searchQuery && filterBy !== 'all'}
+						for "{searchQuery}" in {filterOptions.find(f => f.value === filterBy)?.label.toLowerCase()}
+					{:else if searchQuery}
+						for "{searchQuery}"
+					{:else if filterBy !== 'all'}
+						in {filterOptions.find(f => f.value === filterBy)?.label.toLowerCase()}
+					{/if}
+				{/if}
+			</p>
+		</div>
+	{/if}
 
 	{#if loading}
 		<div class="flex justify-center items-center py-8">

--- a/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
+++ b/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
@@ -132,7 +132,8 @@
 		filteredFileGroups = userFileGroups.filter(group => {
 			const matchesSearch = searchQuery === '' ||
 				group.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-				group.description.toLowerCase().includes(searchQuery.toLowerCase());
+				group.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				group.genomes.some(genome => genome.toLowerCase().includes(searchQuery.toLowerCase()));
 
 			const matchesFilter = filterBy === 'all' ||
 				(filterBy === 'domain' && group.is_domain_specific) ||

--- a/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
+++ b/Part2/Part2_Frontend/src/routes/dashboard/+page.svelte
@@ -84,7 +84,7 @@
 			});
 
 			if (!response.ok) {
-				throw new Error(`Error fetching file groups: ${response.statusText}`);
+				throw new Error(`Error fetching projects: ${response.statusText}`);
 			}
 
 			const data = await response.json();
@@ -170,7 +170,7 @@
 <div class="w-[95%] max-w-[1600px] mx-auto py-8">
 	<div class="mb-8 flex items-start justify-between">
 		<div>
-			<h1 class="text-3xl font-bold text-slate-800 mb-2">Your Uploads</h1>
+			<h1 class="text-3xl font-bold text-slate-800 mb-2">Your Projects</h1>
 			<p class="text-slate-600">Manage and analyze your protein sequence comparisons</p>
 		</div>
 		<a
@@ -190,7 +190,7 @@
 				<input
 					type="text"
 					bind:value={searchQuery}
-					placeholder="Search groups..."
+					placeholder="Search projects..."
 					class="w-full pl-10 pr-4 py-2 bg-white border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
 				/>
 				<svg
@@ -241,7 +241,7 @@
 	{#if !loading && filteredFileGroups.length >= 0}
 		<div class="mb-4">
 			<p class="text-sm text-slate-600">
-				Showing {filteredFileGroups.length} of {userFileGroups.length} group{userFileGroups.length !== 1 ? 's' : ''}
+				Showing {filteredFileGroups.length} of {userFileGroups.length} project{userFileGroups.length !== 1 ? 's' : ''}
 				{#if searchQuery || filterBy !== 'all'}
 					{#if searchQuery && filterBy !== 'all'}
 						for "{searchQuery}" in {filterOptions.find(f => f.value === filterBy)?.label.toLowerCase()}
@@ -326,7 +326,7 @@
 		</div>
 	{:else if !loading}
 		<div class="text-center py-8">
-			<p class="text-slate-600">No file groups found.</p>
+			<p class="text-slate-600">No projects found.</p>
 		</div>
 	{/if}
 </div>

--- a/Part2/Part2_Frontend/src/routes/diagram/+page.svelte
+++ b/Part2/Part2_Frontend/src/routes/diagram/+page.svelte
@@ -201,14 +201,14 @@
     }
 
     if (!isAuthenticated) {
-      alert('Please log in to save groups.');
+      alert('Please log in to save projects.');
       return;
     }
 
     savingGroup = true;
     const formData = new FormData();
     if (!groupId) {
-      // For new groups, validate uploaded files
+      // For new projects, validate uploaded files
       if (!uploadedCoordsFile || uploadedMatrixFiles.length === 0) {
         alert('Please select at least one coordinate file and one matrix file to save.');
         savingGroup = false;
@@ -240,13 +240,13 @@
       if (!response.ok) {
         const errorResponse = await response.json();
         const errorMessage = errorResponse.error || 'Unknown error';
-        console.error('Error saving group:', errorMessage);
-        throw new Error(`Failed to save group: ${response.statusText}`);
+        console.error('Error saving project:', errorMessage);
+        throw new Error(`Failed to save project: ${response.statusText}`);
       }
 
       const result = await response.json();
-      console.log('Group saved successfully:', result);
-      alert('Group updated successfully!');
+      console.log('Project saved successfully:', result);
+      alert('Project updated successfully!');
 
       if (!groupId) {
         // Transition to the view with the new groupId
@@ -256,8 +256,8 @@
         goto(`?groupId=${newGroupId}`);
       }
     } catch (error) {
-      console.error('Error saving group:', error);
-      alert('Failed to save group. Please try again.');
+      console.error('Error saving project:', error);
+      alert('Failed to save project. Please try again.');
     } finally {
       savingGroup = false;
     }
@@ -597,7 +597,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
               <!-- Group info section for authenticated users -->
               <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
-                <h3 class="text-xl font-semibold text-slate-800 mb-4">Group Information</h3>
+                <h3 class="text-xl font-semibold text-slate-800 mb-4">Project Information</h3>
                 <div class="space-y-4">
                   <input
                     type="text"
@@ -626,14 +626,14 @@
                         Saving...
                       </div>
                     {:else}
-                      {groupId ? 'Update Group' : 'Save Group'}
+                      {groupId ? 'Update Project' : 'Save Project'}
                     {/if}
                   </button>
                 </div>
               </div>
 
               {#if groupId && (matrixFiles.length > 0 || coordinateFile)}
-                <!-- Download section only shown for existing groups -->
+                <!-- Download section only shown for existing projects -->
                 <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-4">
                   <h3 class="text-xl font-semibold text-slate-800 mb-3">Download Files</h3>
                   <div class="space-y-4">


### PR DESCRIPTION
Updated dashboard (screenshots below are old oops):
![image](https://github.com/user-attachments/assets/d055936d-51fa-4067-b249-c03351c453e9)
- text has been updated to refer to groups as projects

- there is now a clear button to get to the diagram quickly
- card actions are aligned to the bottom, rather than floating up a bit if the other content is shorter (like description, genome names, etc)
- dropdowns have clear labels now
- can search by genome now
- the number of groups displayed, based on filters applied, is now very clearly visible, with descriptions of the filters applied (examples below:)
![image](https://github.com/user-attachments/assets/4d6b86eb-0d8f-4f4d-89f0-5413ef25c39f)
![image](https://github.com/user-attachments/assets/f946a454-eda9-4cde-a737-685ab90937e8)
![image](https://github.com/user-attachments/assets/7ac116e2-ef3c-4adc-ae60-128bd596dea2)
![image](https://github.com/user-attachments/assets/c505b053-33a2-4970-9d5f-de408f3a3dc9)
![image](https://github.com/user-attachments/assets/56e02eb1-d421-4be6-8414-c35db9d6ada2)
![image](https://github.com/user-attachments/assets/4d6916b4-bedb-4388-a479-0f74e3c1d33d)
