### PR TITLE
add issue template and pr template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -1,0 +1,24 @@
+---
+name: Issue / Feature / Bug
+about: Propose a bug fix, feature, or improvement
+---
+
+## Title
+A short, clear summary (e.g., "Add support for domain‑specific matrices")
+
+## What's the problem?
+Describe the current behavior or lack thereof. For bugs, include reproduction steps.
+
+## Desired outcome
+What should happen instead? Why does it matter?
+
+## Proposed solution
+Outline your approach at a high level.
+
+## Additional context
+Links to design docs, visuals, data formats, etc.
+
+## (Optional) Next steps / Acceptance criteria
+- [ ] Brief manual test
+- [ ] Automated test/spec added (if applicable)
+- [ ] Documentation updated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Title
+Short, descriptive title (e.g. "Add domain‑specific matrix support")
+
+## Issue Link
+(e.g. Fixes #123)
+
+## Description
+- **What**: Describe main changes
+- **Why**: Why this is needed
+
+## Testing and Screenshots
+Explain how reviewers can verify changes.
+Include screenshots or terminal output if relevant.
+
+## Additional notes
+Any other context, migrations, CI notes, etc.


### PR DESCRIPTION
Added issue templates and PR templates; from this point onwards, new issues and PRs should be based on these templates, and have sufficient detail about the changes required/made