### PR TITLE
Local Login fixed by adding Cognito Env Vars in Backend in Docker Config

### DIFF
--- a/Part2/docker-compose.yml
+++ b/Part2/docker-compose.yml
@@ -27,6 +27,9 @@ services:
     environment:
       - DATABASE_URL=postgresql://protein_user:protein_password@db:5432/protein_db
       - ENV=development
+      - AWS_REGION=us-east-1
+      - COGNITO_USER_POOL_ID=us-east-1_Bep0PJNNp
+      - COGNITO_APP_CLIENT_ID=6s0tgt4tnp6s02o1j8tmhgqnem
     volumes:
       - ./Part2_Backend:/app
     depends_on:


### PR DESCRIPTION
## Title
Local Login fixed by adding Cognito Env Vars

## Description
- **What**: Added Cognito Environment Variables to the backend section of the Docker configuration file
- **Why**: On local testing, login works but fetching the backend failed.

## Testing and Screenshots
Run the setup locally