### PR TITLE
Graph report

### DIFF
--- a/Part2/Part2_Frontend/src/lib/Chart.svelte
+++ b/Part2/Part2_Frontend/src/lib/Chart.svelte
@@ -2,6 +2,9 @@
   import { onMount, afterUpdate } from 'svelte';
   import * as d3 from 'd3';
   import UnionFind from '$lib/UnionFind';
+  import { selectionState } from '$lib/report/selectionStore';
+  import { buildAndSetSnapshot } from '$lib/report/reportSnapshot';
+
 
   /**
    * Props
@@ -305,6 +308,33 @@
       return true;
     });
 
+    // --- keep report snapshot in sync (used by ReportButton) ---
+    buildAndSetSnapshot({
+      domain: graph.domain_name,
+      genomes_order: graph.genomes ?? [],
+      filters: {
+        cutoff,
+        showReciprocal,
+        showNonReciprocal,
+        showConsistent,
+        showInconsistent,
+        showPartiallyConsistent
+      },
+      focus_mode: isFocused && (selectedNodes.size > 0 || selectedLinks.size > 0),
+      nodes: nodes.map(n => ({
+        id: n.id.endsWith('__dup') ? n.id.slice(0, -'__dup'.length) : n.id, // normalize duplicate-row ids
+        genome_name: n.genome_name,
+        protein_name: n.protein_name,
+        direction: n.direction,
+        rel_position: n.rel_position,
+        is_present: n.is_present,
+        gene_type: n.gene_type
+      })),
+      links: visibleLinks
+    });
+
+
+
     // Calculate focused nodes and links if in focus mode
     if (isFocused && (selectedNodes.size > 0 || selectedLinks.size > 0)) {
       focusedNodes.clear();
@@ -383,6 +413,7 @@
 
     const nodeById = new Map(nodes.map((n) => [n.id, n]));
     const rowOf = (n: Node) => (n._dup ? genomes.length : genomes.indexOf(n.genome_name));
+
 
     // ── LABELS ──
     const labelSvg = d3.select(labelSvgEl).attr('width', labelWidth).attr('height', height);
@@ -534,6 +565,12 @@
         } else {
           selectedLinks.add(linkId);
         }
+
+        selectionState.set({
+          isFocused,
+          nodes: Array.from(selectedNodes),
+          links: Array.from(selectedLinks)
+        });
         draw();
       })
       .on('mouseover', function (event, d) {
@@ -653,6 +690,11 @@
           }
         });
         selectedNodesCount = selectedNodes.size;
+        selectionState.set({
+          isFocused,
+          nodes: Array.from(selectedNodes),
+          links: Array.from(selectedLinks)
+        });
         draw();
       })
       .on('mouseover', function (event, d) {
@@ -821,12 +863,22 @@
       selectedNodesCount = 0;
       isFocused = false;
     }
+    selectionState.set({
+      isFocused,
+      nodes: Array.from(selectedNodes),
+      links: Array.from(selectedLinks)
+    });
     draw();
   }
 
   function applyFocus() {
     if (selectedNodes.size === 0) return;
     isFocused = true;
+    selectionState.set({
+      isFocused,
+      nodes: Array.from(selectedNodes),
+      links: Array.from(selectedLinks)
+    });
     draw();
   }
 
@@ -834,6 +886,11 @@
     isFocused = false;
     selectedNodes.clear();
     selectedNodesCount = 0;
+    selectionState.set({
+      isFocused,
+      nodes: Array.from(selectedNodes),
+      links: Array.from(selectedLinks)
+    });
     draw();
   }
 

--- a/Part2/Part2_Frontend/src/lib/Chart.svelte
+++ b/Part2/Part2_Frontend/src/lib/Chart.svelte
@@ -379,7 +379,7 @@
     }
 
 
-        // === SNAPSHOT: capture exactly what's being drawn (after focus is computed) ===
+    // === SNAPSHOT: capture exactly what's being drawn (after focus is computed) ===
     const nodesForReport = (isFocused && (selectedNodes.size > 0 || selectedLinks.size > 0))
       ? nodes.filter(n => focusedNodes.has(n.id))
       : nodes;

--- a/Part2/Part2_Frontend/src/lib/Chart.svelte
+++ b/Part2/Part2_Frontend/src/lib/Chart.svelte
@@ -308,31 +308,6 @@
       return true;
     });
 
-    // --- keep report snapshot in sync (used by ReportButton) ---
-    buildAndSetSnapshot({
-      domain: graph.domain_name,
-      genomes_order: graph.genomes ?? [],
-      filters: {
-        cutoff,
-        showReciprocal,
-        showNonReciprocal,
-        showConsistent,
-        showInconsistent,
-        showPartiallyConsistent
-      },
-      focus_mode: isFocused && (selectedNodes.size > 0 || selectedLinks.size > 0),
-      nodes: nodes.map(n => ({
-        id: n.id.endsWith('__dup') ? n.id.slice(0, -'__dup'.length) : n.id, // normalize duplicate-row ids
-        genome_name: n.genome_name,
-        protein_name: n.protein_name,
-        direction: n.direction,
-        rel_position: n.rel_position,
-        is_present: n.is_present,
-        gene_type: n.gene_type
-      })),
-      links: visibleLinks
-    });
-
 
 
     // Calculate focused nodes and links if in focus mode
@@ -402,6 +377,43 @@
         focusedLinks.add(linkId);
       });
     }
+
+
+        // === SNAPSHOT: capture exactly what's being drawn (after focus is computed) ===
+    const nodesForReport = (isFocused && (selectedNodes.size > 0 || selectedLinks.size > 0))
+      ? nodes.filter(n => focusedNodes.has(n.id))
+      : nodes;
+
+    const linksForReport = (isFocused && (selectedNodes.size > 0 || selectedLinks.size > 0))
+      // keep only links whose BOTH endpoints are in the focused set
+      ? visibleLinks.filter(l => focusedNodes.has(l.source) && focusedNodes.has(l.target))
+      : visibleLinks;
+
+    buildAndSetSnapshot({
+      domain: graph.domain_name,
+      genomes_order: graph.genomes ?? [],
+      filters: {
+        cutoff,
+        showReciprocal,
+        showNonReciprocal,
+        showConsistent,
+        showInconsistent,
+        showPartiallyConsistent
+      },
+      focus_mode: isFocused && (selectedNodes.size > 0 || selectedLinks.size > 0),
+      nodes: nodesForReport.map(n => ({
+        id: n.id.endsWith('__dup') ? n.id.slice(0, -'__dup'.length) : n.id,
+        genome_name: n.genome_name,
+        protein_name: n.protein_name,
+        direction: n.direction,
+        rel_position: n.rel_position,
+        is_present: n.is_present,
+        gene_type: n.gene_type
+      })),
+      links: linksForReport
+    });
+    // === END SNAPSHOT ===
+
 
     // scales
     const numRows = genomes.length > 2 ? genomes.length + 1 : genomes.length; // Updated so no extra line when there are only 2 genomes

--- a/Part2/Part2_Frontend/src/lib/components/ReportDownloadButton.svelte
+++ b/Part2/Part2_Frontend/src/lib/components/ReportDownloadButton.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { get } from 'svelte/store';
+  import { reportSnapshot } from '$lib/report/reportSnapshot';
+
+  export let currentGraph: { genomes: string[] } | null = null;
+  export let filters: {
+    cutoff: number;
+    showReciprocal: boolean;
+    showNonReciprocal: boolean;
+    showConsistent: boolean;
+    showInconsistent: boolean;
+    showPartiallyConsistent: boolean;
+  };
+
+  function fmtPct(v: number) {
+    // Defensive: keep one decimal if needed
+    return Number.isFinite(v) ? (Math.round(v * 10) / 10).toString() + '%' : '—';
+    // but our scores are already integers most of the time
+  }
+
+  function normalizeId(id: string) {
+    return id?.endsWith('__dup') ? id.slice(0, -'__dup'.length) : id;
+  }
+
+  function byGenome(nodes: any[], genomes: string[]) {
+    const map = new Map<string, any[]>();
+    genomes.forEach(g => map.set(g, []));
+    nodes.forEach(n => {
+      const g = n.genome_name;
+      if (!map.has(g)) map.set(g, []);
+      // keep a single entry per logical node id (dedupe dup copies)
+      const arr = map.get(g)!;
+      if (!arr.some(x => normalizeId(x.id) === normalizeId(n.id))) arr.push(n);
+    });
+    return map;
+  }
+
+  function linkDetail(l: any) {
+    if ('score' in l) {
+      return `${l.is_reciprocal ? 'Reciprocal' : 'Non-reciprocal'}, Similarity ${fmtPct(l.score)}`;
+    }
+    // ALL-domain compare link
+    if (l.link_type === 'solid_red') return 'Inconsistent across domains';
+    if (l.link_type === 'solid_color') return 'Consistent across domains';
+    if (l.link_type === 'dotted_color') return 'Partially consistent';
+    if (l.link_type === 'dotted_grey' || l.link_type === 'dotted_gray') return 'Non-reciprocal';
+    return l.link_type ?? 'Unknown';
+  }
+
+  function safeName(nodesById: Map<string, any>, id: string) {
+    const n = nodesById.get(normalizeId(id));
+    return n ? `${n.protein_name} (${n.genome_name})` : id;
+  }
+
+  function buildMarkdown() {
+    const snap = get(reportSnapshot);
+    if (!snap) {
+      alert('No graph is visible to report on yet.');
+      return null;
+    }
+
+    // Prepare helpers
+    const genomes = snap.genomes_order ?? [];
+    const nodes = dedupeNodes(snap.nodes);
+    const nodesById = new Map(nodes.map(n => [normalizeId(n.id), n]));
+    const visibleLinks = dedupeLinks(snap.links);
+
+    const lines: string[] = [];
+    // Header (like your preferred sample)  ─────────────────────────
+    lines.push(`# Current Graph Report`);
+    lines.push('');
+    lines.push(`- **Generated:** ${new Date(snap.generated_at).toISOString().slice(0,16).replace('T',' ')}`);
+    if (snap.domain) lines.push(`- **Domain:** ${snap.domain}`);
+    if (genomes.length) lines.push(`- **Selected Genomes (order):** ${genomes.join('  →  ')}`);
+    lines.push('');
+    lines.push(`## Active Filters`);
+    lines.push(`- Cut-off: ${snap.filters.cutoff}%`);
+    if (snap.domain === 'ALL') {
+      lines.push(`- Consistent: ${snap.filters.showConsistent ? 'ON' : 'OFF'}`);
+      lines.push(`- Inconsistent: ${snap.filters.showInconsistent ? 'ON' : 'OFF'}`);
+      lines.push(`- Partially consistent: ${snap.filters.showPartiallyConsistent ? 'ON' : 'OFF'}`);
+      lines.push(`- Non-reciprocal: ${snap.filters.showNonReciprocal ? 'ON' : 'OFF'}`);
+    } else {
+      lines.push(`- Reciprocal: ${snap.filters.showReciprocal ? 'ON' : 'OFF'}`);
+      lines.push(`- Non-reciprocal: ${snap.filters.showNonReciprocal ? 'ON' : 'OFF'}`);
+    }
+    lines.push('');
+
+    // Summary  ─────────────────────────────────────────────────────
+    lines.push(`## Summary`);
+    lines.push(`- **Visible nodes:** ${nodes.length}`);
+    lines.push(`- **Visible links:** ${visibleLinks.length}`);
+    lines.push('');
+
+    // Per-genome sections  ─────────────────────────────────────────
+    const grouped = byGenome(nodes, genomes);
+    for (const g of genomes) {
+      const list = grouped.get(g) ?? [];
+      if (!list.length) continue;
+
+      lines.push(`## Nodes (In Current View)`);
+      lines.push(`### Genome: ${g}`);
+
+      for (const n of list.sort((a,b) => a.rel_position - b.rel_position)) {
+        lines.push(`**Protein:** ${n.protein_name}`);
+        lines.push(`- Node ID: \`${normalizeId(n.id)}\``);
+        lines.push(`- Gene/Domain type: ${n.gene_type ?? '—'}`);
+        lines.push(`- Present: ${n.is_present === false ? 'NO' : 'YES'}`);
+        lines.push(`- Direction: ${n.direction === 'plus' ? '+' : '-'}`);
+        lines.push(`- Relative position: ${n.rel_position}`);
+        lines.push('');
+        // Node-local links (shown like the preferred sample)
+        const local = visibleLinks.filter(l =>
+          normalizeId(l.source) === normalizeId(n.id) || normalizeId(l.target) === normalizeId(n.id)
+        );
+        if (local.length) {
+          lines.push(`**Links:**  `);
+          // show as bulleted; other side’s label is “ProteinName (Genome)”
+          for (const l of local) {
+            const a = normalizeId(l.source);
+            const b = normalizeId(l.target);
+            const other = a === normalizeId(n.id) ? b : a;
+            lines.push(`- ${safeName(nodesById, other)} — ${linkDetail(l)}`);
+          }
+          lines.push('');
+        } else {
+          lines.push(`**Links:**  `);
+          lines.push(`- (no visible links under current filters)`);
+          lines.push('');
+        }
+      }
+    }
+
+    // Final links table  ───────────────────────────────────────────
+    lines.push('');
+    lines.push(`## Links (In Current View)`);
+    lines.push(`| Source | Target | Details |`);
+    lines.push(`|---|---|---|`);
+    for (const l of visibleLinks) {
+      const src = safeName(nodesById, l.source);
+      const tgt = safeName(nodesById, l.target);
+      lines.push(`| ${src} | ${tgt} | ${linkDetail(l)} |`);
+    }
+
+    return lines.join('\n');
+  }
+
+  // De-dup helpers (avoid double entries when dup row exists)
+  function dedupeNodes(nodes: any[]) {
+    const seen = new Set<string>();
+    const out: any[] = [];
+    for (const n of nodes) {
+      const key = normalizeId(n.id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ ...n, id: key });
+    }
+    return out;
+    }
+
+  function dedupeLinks(links: any[]) {
+    const seen = new Set<string>();
+    const out: any[] = [];
+    for (const l of links) {
+      const a = normalizeId(l.source);
+      const b = normalizeId(l.target);
+      // undirected key for table + node sections
+      const key = a < b ? `${a}|${b}|${'score' in l ? l.score : l.link_type}` : `${b}|${a}|${'score' in l ? l.score : l.link_type}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ ...l, source: a, target: b });
+    }
+    return out;
+  }
+
+  function downloadReport() {
+    const md = buildMarkdown();
+    if (!md) return;
+
+    const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const stamp = new Date().toISOString().slice(0,16).replace(/[:T]/g,'-');
+    a.href = url;
+    a.download = `graph-report-${stamp}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<button
+  on:click={downloadReport}
+  class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition-colors duration-200 cursor-pointer"
+>
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+    <polyline points="7 10 12 15 17 10"/>
+    <line x1="12" y1="15" x2="12" y2="3"/>
+  </svg>
+  Download Report
+</button>

--- a/Part2/Part2_Frontend/src/lib/components/ReportDownloadButton.svelte
+++ b/Part2/Part2_Frontend/src/lib/components/ReportDownloadButton.svelte
@@ -2,44 +2,50 @@
   import { get } from 'svelte/store';
   import { reportSnapshot } from '$lib/report/reportSnapshot';
 
-  export let currentGraph: { genomes: string[] } | null = null;
-  export let filters: {
-    cutoff: number;
-    showReciprocal: boolean;
-    showNonReciprocal: boolean;
-    showConsistent: boolean;
-    showInconsistent: boolean;
-    showPartiallyConsistent: boolean;
-  };
+  let open = false;
 
-  function fmtPct(v: number) {
-    // Defensive: keep one decimal if needed
-    return Number.isFinite(v) ? (Math.round(v * 10) / 10).toString() + '%' : '—';
-    // but our scores are already integers most of the time
-  }
-
+  // ----- helpers (same data model you already use) -----
   function normalizeId(id: string) {
     return id?.endsWith('__dup') ? id.slice(0, -'__dup'.length) : id;
   }
 
-  function byGenome(nodes: any[], genomes: string[]) {
-    const map = new Map<string, any[]>();
-    genomes.forEach(g => map.set(g, []));
-    nodes.forEach(n => {
-      const g = n.genome_name;
-      if (!map.has(g)) map.set(g, []);
-      // keep a single entry per logical node id (dedupe dup copies)
-      const arr = map.get(g)!;
-      if (!arr.some(x => normalizeId(x.id) === normalizeId(n.id))) arr.push(n);
-    });
-    return map;
+  function dedupeNodes(nodes: any[]) {
+    const seen = new Set<string>();
+    const out: any[] = [];
+    for (const n of nodes ?? []) {
+      const key = normalizeId(n.id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ ...n, id: key });
+    }
+    return out;
+  }
+
+  function dedupeLinks(links: any[]) {
+    const seen = new Set<string>();
+    const out: any[] = [];
+    for (const l of links ?? []) {
+      const a = normalizeId(l.source);
+      const b = normalizeId(l.target);
+      const bucket = 'score' in l ? `score:${l.score}` : `type:${l.link_type}`;
+      const key = a < b ? `${a}|${b}|${bucket}` : `${b}|${a}|${bucket}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ ...l, source: a, target: b });
+    }
+    return out;
+  }
+
+  function fmtPct(v: number) {
+    if (!Number.isFinite(v as any)) return '—';
+    const n = Math.round((v as number) * 10) / 10;
+    return `${n}%`;
   }
 
   function linkDetail(l: any) {
     if ('score' in l) {
       return `${l.is_reciprocal ? 'Reciprocal' : 'Non-reciprocal'}, Similarity ${fmtPct(l.score)}`;
     }
-    // ALL-domain compare link
     if (l.link_type === 'solid_red') return 'Inconsistent across domains';
     if (l.link_type === 'solid_color') return 'Consistent across domains';
     if (l.link_type === 'dotted_color') return 'Partially consistent';
@@ -52,21 +58,38 @@
     return n ? `${n.protein_name} (${n.genome_name})` : id;
   }
 
-  function buildMarkdown() {
+  function groupByGenome(nodes: any[], genomes: string[]) {
+    const map = new Map<string, any[]>();
+    genomes.forEach(g => map.set(g, []));
+    nodes.forEach(n => {
+      const g = n.genome_name;
+      if (!map.has(g)) map.set(g, []);
+      const arr = map.get(g)!;
+      if (!arr.some(x => normalizeId(x.id) === normalizeId(n.id))) arr.push(n);
+    });
+    return map;
+  }
+
+  function getReportData() {
     const snap = get(reportSnapshot);
     if (!snap) {
       alert('No graph is visible to report on yet.');
       return null;
     }
-
-    // Prepare helpers
     const genomes = snap.genomes_order ?? [];
-    const nodes = dedupeNodes(snap.nodes);
+    const nodes = dedupeNodes(snap.nodes ?? []);
     const nodesById = new Map(nodes.map(n => [normalizeId(n.id), n]));
-    const visibleLinks = dedupeLinks(snap.links);
+    const links = dedupeLinks(snap.links ?? []);
+    return { snap, genomes, nodes, nodesById, links };
+  }
+
+  // ----- builders for each format -----
+  function buildMarkdown() {
+    const data = getReportData();
+    if (!data) return null;
+    const { snap, genomes, nodes, nodesById, links } = data;
 
     const lines: string[] = [];
-    // Header (like your preferred sample)  ─────────────────────────
     lines.push(`# Current Graph Report`);
     lines.push('');
     lines.push(`- **Generated:** ${new Date(snap.generated_at).toISOString().slice(0,16).replace('T',' ')}`);
@@ -84,16 +107,15 @@
       lines.push(`- Reciprocal: ${snap.filters.showReciprocal ? 'ON' : 'OFF'}`);
       lines.push(`- Non-reciprocal: ${snap.filters.showNonReciprocal ? 'ON' : 'OFF'}`);
     }
+    if ((snap as any).focus_mode) lines.push(`- Focus mode: ON`);
     lines.push('');
 
-    // Summary  ─────────────────────────────────────────────────────
     lines.push(`## Summary`);
     lines.push(`- **Visible nodes:** ${nodes.length}`);
-    lines.push(`- **Visible links:** ${visibleLinks.length}`);
+    lines.push(`- **Visible links:** ${links.length}`);
     lines.push('');
 
-    // Per-genome sections  ─────────────────────────────────────────
-    const grouped = byGenome(nodes, genomes);
+    const grouped = groupByGenome(nodes, genomes);
     for (const g of genomes) {
       const list = grouped.get(g) ?? [];
       if (!list.length) continue;
@@ -109,34 +131,30 @@
         lines.push(`- Direction: ${n.direction === 'plus' ? '+' : '-'}`);
         lines.push(`- Relative position: ${n.rel_position}`);
         lines.push('');
-        // Node-local links (shown like the preferred sample)
-        const local = visibleLinks.filter(l =>
+
+        const local = links.filter(l =>
           normalizeId(l.source) === normalizeId(n.id) || normalizeId(l.target) === normalizeId(n.id)
         );
+        lines.push(`**Links:**  `);
         if (local.length) {
-          lines.push(`**Links:**  `);
-          // show as bulleted; other side’s label is “ProteinName (Genome)”
           for (const l of local) {
             const a = normalizeId(l.source);
             const b = normalizeId(l.target);
             const other = a === normalizeId(n.id) ? b : a;
             lines.push(`- ${safeName(nodesById, other)} — ${linkDetail(l)}`);
           }
-          lines.push('');
         } else {
-          lines.push(`**Links:**  `);
           lines.push(`- (no visible links under current filters)`);
-          lines.push('');
         }
+        lines.push('');
       }
     }
 
-    // Final links table  ───────────────────────────────────────────
     lines.push('');
     lines.push(`## Links (In Current View)`);
     lines.push(`| Source | Target | Details |`);
     lines.push(`|---|---|---|`);
-    for (const l of visibleLinks) {
+    for (const l of links) {
       const src = safeName(nodesById, l.source);
       const tgt = safeName(nodesById, l.target);
       lines.push(`| ${src} | ${tgt} | ${linkDetail(l)} |`);
@@ -145,59 +163,292 @@
     return lines.join('\n');
   }
 
-  // De-dup helpers (avoid double entries when dup row exists)
-  function dedupeNodes(nodes: any[]) {
-    const seen = new Set<string>();
-    const out: any[] = [];
-    for (const n of nodes) {
-      const key = normalizeId(n.id);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push({ ...n, id: key });
+  function buildTXT() {
+    const data = getReportData();
+    if (!data) return null;
+    const { snap, genomes, nodes, nodesById, links } = data;
+
+    const lines: string[] = [];
+    lines.push(`Current Graph Report`);
+    lines.push(`Generated: ${new Date(snap.generated_at).toISOString().slice(0,16).replace('T',' ')}`);
+    if (snap.domain) lines.push(`Domain: ${snap.domain}`);
+    if (genomes.length) lines.push(`Selected Genomes (order): ${genomes.join(' -> ')}`);
+    if ((snap as any).focus_mode) lines.push(`Focus mode: ON`);
+    lines.push('');
+
+    lines.push(`Active Filters`);
+    lines.push(`- Cut-off: ${snap.filters.cutoff}%`);
+    if (snap.domain === 'ALL') {
+      lines.push(`- Consistent: ${snap.filters.showConsistent ? 'ON' : 'OFF'}`);
+      lines.push(`- Inconsistent: ${snap.filters.showInconsistent ? 'ON' : 'OFF'}`);
+      lines.push(`- Partially consistent: ${snap.filters.showPartiallyConsistent ? 'ON' : 'OFF'}`);
+      lines.push(`- Non-reciprocal: ${snap.filters.showNonReciprocal ? 'ON' : 'OFF'}`);
+    } else {
+      lines.push(`- Reciprocal: ${snap.filters.showReciprocal ? 'ON' : 'OFF'}`);
+      lines.push(`- Non-reciprocal: ${snap.filters.showNonReciprocal ? 'ON' : 'OFF'}`);
     }
-    return out;
+    lines.push('');
+
+    lines.push(`Summary`);
+    lines.push(`- Visible nodes: ${nodes.length}`);
+    lines.push(`- Visible links: ${links.length}`);
+    lines.push('');
+
+    const grouped = groupByGenome(nodes, genomes);
+    for (const g of genomes) {
+      const list = grouped.get(g) ?? [];
+      if (!list.length) continue;
+      lines.push(`Nodes (Genome: ${g})`);
+      for (const n of list.sort((a,b) => a.rel_position - b.rel_position)) {
+        lines.push(`Protein: ${n.protein_name}`);
+        lines.push(`  Node ID: ${normalizeId(n.id)}`);
+        lines.push(`  Gene/Domain type: ${n.gene_type ?? '—'}`);
+        lines.push(`  Present: ${n.is_present === false ? 'NO' : 'YES'}`);
+        lines.push(`  Direction: ${n.direction === 'plus' ? '+' : '-'}`);
+        lines.push(`  Relative position: ${n.rel_position}`);
+        const local = links.filter(l =>
+          normalizeId(l.source) === normalizeId(n.id) || normalizeId(l.target) === normalizeId(n.id)
+        );
+        lines.push(`  Links:`);
+        if (local.length) {
+          for (const l of local) {
+            const a = normalizeId(l.source);
+            const b = normalizeId(l.target);
+            const other = a === normalizeId(n.id) ? b : a;
+            lines.push(`    - ${safeName(nodesById, other)} — ${linkDetail(l)}`);
+          }
+        } else {
+          lines.push(`    - (no visible links under current filters)`);
+        }
+        lines.push('');
+      }
     }
 
-  function dedupeLinks(links: any[]) {
-    const seen = new Set<string>();
-    const out: any[] = [];
+    lines.push(`Links (In Current View)`);
     for (const l of links) {
-      const a = normalizeId(l.source);
-      const b = normalizeId(l.target);
-      // undirected key for table + node sections
-      const key = a < b ? `${a}|${b}|${'score' in l ? l.score : l.link_type}` : `${b}|${a}|${'score' in l ? l.score : l.link_type}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push({ ...l, source: a, target: b });
+      lines.push(`- ${safeName(nodesById, l.source)}  <->  ${safeName(nodesById, l.target)}  |  ${linkDetail(l)}`);
     }
-    return out;
+
+    return lines.join('\n');
   }
 
-  function downloadReport() {
-    const md = buildMarkdown();
-    if (!md) return;
+  function buildHTML() {
+    const data = getReportData();
+    if (!data) return null;
+    const { snap, genomes, nodes, nodesById, links } = data;
 
-    const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+    const esc = (s: string) => String(s)
+      .replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');
+
+    const sections: string[] = [];
+    sections.push(`<h1>Current Graph Report</h1>`);
+    sections.push(`<ul>`);
+    sections.push(`<li><strong>Generated:</strong> ${esc(new Date(snap.generated_at).toISOString().slice(0,16).replace('T',' '))}</li>`);
+    if (snap.domain) sections.push(`<li><strong>Domain:</strong> ${esc(snap.domain)}</li>`);
+    if (genomes.length) sections.push(`<li><strong>Selected Genomes (order):</strong> ${esc(genomes.join(' → '))}</li>`);
+    if ((snap as any).focus_mode) sections.push(`<li><strong>Focus mode:</strong> ON</li>`);
+    sections.push(`</ul>`);
+
+    sections.push(`<h2>Active Filters</h2>`);
+    const af: string[] = [];
+    af.push(`<li>Cut-off: ${esc(String(snap.filters.cutoff))}%</li>`);
+    if (snap.domain === 'ALL') {
+      af.push(`<li>Consistent: ${snap.filters.showConsistent ? 'ON' : 'OFF'}</li>`);
+      af.push(`<li>Inconsistent: ${snap.filters.showInconsistent ? 'ON' : 'OFF'}</li>`);
+      af.push(`<li>Partially consistent: ${snap.filters.showPartiallyConsistent ? 'ON' : 'OFF'}</li>`);
+      af.push(`<li>Non-reciprocal: ${snap.filters.showNonReciprocal ? 'ON' : 'OFF'}</li>`);
+    } else {
+      af.push(`<li>Reciprocal: ${snap.filters.showReciprocal ? 'ON' : 'OFF'}</li>`);
+      af.push(`<li>Non-reciprocal: ${snap.filters.showNonReciprocal ? 'ON' : 'OFF'}</li>`);
+    }
+    sections.push(`<ul>${af.join('')}</ul>`);
+
+    sections.push(`<h2>Summary</h2>`);
+    sections.push(`<ul>`);
+    sections.push(`<li><strong>Visible nodes:</strong> ${nodes.length}</li>`);
+    sections.push(`<li><strong>Visible links:</strong> ${links.length}</li>`);
+    sections.push(`</ul>`);
+
+    const grouped = groupByGenome(nodes, genomes);
+    for (const g of genomes) {
+      const list = grouped.get(g) ?? [];
+      if (!list.length) continue;
+
+      sections.push(`<h2>Nodes (In Current View)</h2>`);
+      sections.push(`<h3>Genome: ${esc(g)}</h3>`);
+
+      for (const n of list.sort((a,b) => a.rel_position - b.rel_position)) {
+        const nodeRows: string[] = [];
+        nodeRows.push(`<tr><td><strong>Protein</strong></td><td>${esc(n.protein_name)}</td></tr>`);
+        nodeRows.push(`<tr><td>Node ID</td><td><code>${esc(normalizeId(n.id))}</code></td></tr>`);
+        nodeRows.push(`<tr><td>Gene/Domain type</td><td>${esc(n.gene_type ?? '—')}</td></tr>`);
+        nodeRows.push(`<tr><td>Present</td><td>${n.is_present === false ? 'NO' : 'YES'}</td></tr>`);
+        nodeRows.push(`<tr><td>Direction</td><td>${n.direction === 'plus' ? '+' : '-'}</td></tr>`);
+        nodeRows.push(`<tr><td>Relative position</td><td>${n.rel_position}</td></tr>`);
+
+        const local = links.filter(l =>
+          normalizeId(l.source) === normalizeId(n.id) || normalizeId(l.target) === normalizeId(n.id)
+        );
+        const linkLis = local.length
+          ? local.map(l => {
+              const a = normalizeId(l.source);
+              const b = normalizeId(l.target);
+              const other = a === normalizeId(n.id) ? b : a;
+              return `<li>${esc(safeName(nodesById, other))} — ${esc(linkDetail(l))}</li>`;
+            }).join('')
+          : `<li>(no visible links under current filters)</li>`;
+
+        sections.push(`
+          <table class="node"><tbody>${nodeRows.join('')}</tbody></table>
+          <div class="links"><strong>Links:</strong><ul>${linkLis}</ul></div>
+        `);
+      }
+    }
+
+    const linkRows = links.map(l =>
+      `<tr><td>${esc(safeName(nodesById, l.source))}</td><td>${esc(safeName(nodesById, l.target))}</td><td>${esc(linkDetail(l))}</td></tr>`
+    ).join('');
+
+    const html = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Graph Report</title>
+<style>
+  body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; line-height: 1.45; padding: 24px; color: #0f172a; }
+  h1 { font-size: 22px; margin: 0 0 12px; }
+  h2 { font-size: 18px; margin: 20px 0 8px; }
+  h3 { font-size: 15px; margin: 14px 0 6px; }
+  table { border-collapse: collapse; width: 100%; margin: 8px 0 14px; }
+  table.node td { padding: 6px 8px; border-bottom: 1px solid #e2e8f0; vertical-align: top; }
+  table.links, .links ul { margin-top: 6px; }
+  table.links th, table.links td { padding: 6px 8px; border-bottom: 1px solid #e2e8f0; }
+  code { background: #f1f5f9; padding: 1px 4px; border-radius: 4px; }
+  ul { margin: 6px 0 10px 18px; }
+</style>
+</head>
+<body>
+  ${sections.join('\n')}
+  <h2>Links (In Current View)</h2>
+  <table class="links">
+    <thead><tr><th>Source</th><th>Target</th><th>Details</th></tr></thead>
+    <tbody>${linkRows}</tbody>
+  </table>
+</body>
+</html>`;
+    return html;
+  }
+
+  function buildJSON() {
+    const data = getReportData();
+    if (!data) return null;
+    const { snap, genomes, nodes, links } = data;
+    const payload = {
+      meta: {
+        generated_at: snap.generated_at,
+        domain: snap.domain ?? null,
+        genomes_order: genomes,
+        focus_mode: !!(snap as any).focus_mode,
+        filters: snap.filters
+      },
+      nodes,
+      links
+    };
+    return JSON.stringify(payload, null, 2);
+  }
+
+  // ----- download plumbing -----
+  function download(base: string, ext: string, content: string, mime: string) {
+    const blob = new Blob([content], { type: `${mime};charset=utf-8` });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     const stamp = new Date().toISOString().slice(0,16).replace(/[:T]/g,'-');
     a.href = url;
-    a.download = `graph-report-${stamp}.md`;
+    a.download = `${base}-${stamp}${ext}`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   }
+
+  function onChoose(kind: 'md' | 'html' | 'txt' | 'json') {
+    let data: string | null = null;
+    let mime = 'text/plain';
+    let ext = '.txt';
+
+    if (kind === 'md') { data = buildMarkdown(); mime = 'text/markdown'; ext = '.md'; }
+    else if (kind === 'html') { data = buildHTML(); mime = 'text/html'; ext = '.html'; }
+    else if (kind === 'json') { data = buildJSON(); mime = 'application/json'; ext = '.json'; }
+    else { data = buildTXT(); mime = 'text/plain'; ext = '.txt'; }
+
+    if (data) download('graph-report', ext, data, mime);
+    open = false;
+  }
+
+  function toggleMenu() { open = !open; }
+  function closeOnEscape(e: KeyboardEvent) { if (e.key === 'Escape') open = false; }
 </script>
 
-<button
-  on:click={downloadReport}
-  class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition-colors duration-200 cursor-pointer"
->
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
-    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-    <polyline points="7 10 12 15 17 10"/>
-    <line x1="12" y1="15" x2="12" y2="3"/>
-  </svg>
-  Download Report
-</button>
+<div class="relative inline-block">
+  <button
+    on:click={toggleMenu}
+    on:keydown={closeOnEscape}
+    aria-haspopup="true"
+    aria-expanded={open}
+    class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition-colors duration-200 cursor-pointer"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+      <polyline points="7 10 12 15 17 10"/>
+      <line x1="12" y1="15" x2="12" y2="3"/>
+    </svg>
+    Download Report
+    <svg xmlns="http://www.w3.org/2000/svg" class="ml-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <polyline points="6 9 12 15 18 9"></polyline>
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      class="menu"
+      role="menu"
+      aria-label="Download format"
+      on:keydown={closeOnEscape}
+    >
+      <button role="menuitem" on:click={() => onChoose('md')}>Markdown (.md)</button>
+      <button role="menuitem" on:click={() => onChoose('html')}>HTML (.html)</button>
+      <button role="menuitem" on:click={() => onChoose('txt')}>Plain Text (.txt)</button>
+      <button role="menuitem" on:click={() => onChoose('json')}>JSON (.json)</button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 6px;
+    min-width: 180px;
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    box-shadow: 0 6px 16px rgba(2,6,23,0.15);
+    padding: 6px;
+    z-index: 20;
+  }
+  .menu button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 8px 10px;
+    font-size: 14px;
+    border: 0;
+    background: transparent;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .menu button:hover {
+    background: #f1f5f9;
+  }
+</style>

--- a/Part2/Part2_Frontend/src/lib/report/reportSnapshot.ts
+++ b/Part2/Part2_Frontend/src/lib/report/reportSnapshot.ts
@@ -1,0 +1,101 @@
+// src/lib/report/reportSnapshot.ts
+import { writable, get } from 'svelte/store';
+
+export type VisibleNode = {
+  id: string;
+  genome_name: string;
+  protein_name: string;
+  direction: 'plus' | 'minus';
+  rel_position: number;
+  is_present?: boolean;
+  gene_type?: string;
+  _dup?: boolean;
+};
+
+export type ScoreLink =
+  | { source: string; target: string; score: number; is_reciprocal: boolean };
+
+export type CompareLink =
+  | { source: string; target: string; link_type: 'solid_color' | 'solid_red' | 'dotted_color' | 'dotted_grey' | 'dotted_gray' };
+
+export type VisibleLink = ScoreLink | CompareLink;
+
+export type Filters = {
+  cutoff: number;
+  showReciprocal: boolean;
+  showNonReciprocal: boolean;
+  showConsistent: boolean;
+  showInconsistent: boolean;
+  showPartiallyConsistent: boolean;
+};
+
+export type Snapshot = {
+  generated_at: number;
+  domain: string | undefined;
+  genomes_order: string[];
+  filters: {
+    cutoff: number;
+    showReciprocal: boolean;
+    showNonReciprocal: boolean;
+    showConsistent: boolean;
+    showInconsistent: boolean;
+    showPartiallyConsistent: boolean;
+  };
+  focus_mode: boolean;
+  nodes: Array<{
+    id: string;
+    genome_name: string;
+    protein_name: string;
+    direction: string;   // "plus" | "minus"
+    rel_position: number;
+    is_present?: boolean;
+    gene_type?: string;
+  }>;
+  // Only links that are visible under current filters (already filtered in Chart)
+  links: Array<
+    | { source: string; target: string; score: number; is_reciprocal: boolean }
+    | { source: string; target: string; link_type: string }
+  >;
+};
+
+export const reportSnapshot = writable<Snapshot | null>(null);
+
+/** Helpers */
+const DUP_SUFFIX = '__dup';
+const canonicalId = (id: string) => id.endsWith(DUP_SUFFIX) ? id.slice(0, -DUP_SUFFIX.length) : id;
+const undirectedKey = (a: string, b: string) => {
+  const [x, y] = [a, b].map(canonicalId).sort();
+  return `${x}|${y}`;
+};
+
+function linkDetailsFrom(l: VisibleLink) {
+  if ('score' in l) {
+    return {
+      kind: 'score' as const,
+      type: l.is_reciprocal ? 'reciprocal' as const : 'non_reciprocal' as const,
+      similarity: l.score
+    };
+  }
+  // CompareLink
+  switch (l.link_type) {
+    case 'solid_color':   return { kind: 'compare' as const, type: 'consistent' as const };
+    case 'solid_red':     return { kind: 'compare' as const, type: 'inconsistent' as const };
+    case 'dotted_color':  return { kind: 'compare' as const, type: 'partially_consistent' as const };
+    case 'dotted_grey':
+    case 'dotted_gray':   return { kind: 'compare' as const, type: 'non_reciprocal' as const };
+    default:              return { kind: 'compare' as const, type: 'non_reciprocal' as const };
+  }
+}
+
+/**
+ * Build a snapshot of exactly what is being shown and save it to the store.
+ * - Deduplicates nodes by stripping "__dup"
+ * - Deduplicates links by (canonical source, canonical target)
+ * - If multiple links collapse to same pair, prefers a scored link with max similarity; else keeps any compare type with priority:
+ *     consistent > partially_consistent > inconsistent > non_reciprocal
+ */
+export function buildAndSetSnapshot(input: Omit<Snapshot, 'generated_at'>) {
+  const snap: Snapshot = { ...input, generated_at: Date.now() };
+  reportSnapshot.set(snap);
+  return snap;
+}

--- a/Part2/Part2_Frontend/src/lib/report/selectionStore.ts
+++ b/Part2/Part2_Frontend/src/lib/report/selectionStore.ts
@@ -1,0 +1,14 @@
+// src/lib/report/selectionStore.ts
+import { writable } from 'svelte/store';
+
+export type SelectionState = {
+  isFocused: boolean;
+  nodes: string[]; // selected node ids (may contain dup ids)
+  links: string[]; // `${source}-${target}` (may contain dup ids)
+};
+
+export const selectionState = writable<SelectionState>({
+  isFocused: false,
+  nodes: [],
+  links: []
+});

--- a/Part2/Part2_Frontend/src/routes/diagram/+page.svelte
+++ b/Part2/Part2_Frontend/src/routes/diagram/+page.svelte
@@ -6,6 +6,8 @@
   import { oidcClient } from '$lib/auth'
   import { getTokens } from '$lib/getTokens';
   import UploadModal from '$lib/components/UploadModal.svelte';
+  import ReportDownloadButton from '$lib/components/ReportDownloadButton.svelte';
+
 
   interface Node {
     id: string;
@@ -592,6 +594,7 @@
                 </svg>
                 Upload New Files
               </button>
+              <ReportDownloadButton/>
             {/if}
           </div>
         {/if}


### PR DESCRIPTION
Added Report feature

## Issue Link
(e.g. Fixes #143 )

## Description
Users can now take a snapshot of their current graph environment and download a detailed report based on that exact view. The report fully reflects the user’s active selection mode, filters, and any adjustments made to the graph. After configuring the graph, users can click the Download Graph button and choose from multiple file types to export the snapshot.

The web tool is highly interactive, allowing users to explore and refine the graph dynamically. Because the graph’s insights depend on user-driven adjustments, this leads to users having to actively interact with the graph to gain details. The new snapshot-based report lets users fine-tune the graph to their preference and then export a detailed output that accurately represents the exact view they created.

## Testing and Screenshots
Explain how reviewers can verify changes.
Include screenshots or terminal output if relevant.

## Additional notes
Any other context, migrations, CI notes, etc.