### PR TITLE
Reverting and pinning zappa version to 0.60.2 (where it worked last deployment)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
           source venv/bin/activate
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install --upgrade zappa
+          pip install "zappa==0.60.2"
           if zappa status -s zappa_settings.json dev >/dev/null 2>&1; then
             zappa update -s zappa_settings.json dev
           else


### PR DESCRIPTION
## Issue Link
N/A

## Description
- **What**: Pinned zappa version to 0.60.2 in deploy.yml
- **Why**: Latest version of zappa had some importlib.py issue

## Testing and Screenshots
N/A, deployment works after change